### PR TITLE
Create flags to enable logs when call methods with fibers is in use.

### DIFF
--- a/fibers.js
+++ b/fibers.js
@@ -96,7 +96,7 @@ function setupAsyncHacks(Fiber) {
 			}
 
 			const { LOG_USE_FIBERS_INCLUDE_IN_PATH } = process.env;
-			const stackFromError = new Error("[FIBERS_LOG]").stack;
+			const stackFromError = new Error(`[FIBERS_LOG] Using ${fibersMethod}.`).stack;
 
 			if (
 				!LOG_USE_FIBERS_INCLUDE_IN_PATH ||

--- a/fibers.js
+++ b/fibers.js
@@ -86,13 +86,23 @@ function setupAsyncHacks(Fiber) {
 		}
 
 		function logUsingFibers(fibersMethod) {
-			const { ENABLE_LOG_USE_FIBERS } = process.env;
+			const logUseFibersLevel = +(process.env.ENABLE_LOG_USE_FIBERS || 0);
 
-			if (!ENABLE_LOG_USE_FIBERS) return;
+			if (!logUseFibersLevel) return;
 
-			console.warn(`[FIBERS_LOG] Using ${fibersMethod}.`);
-			if (ENABLE_LOG_USE_FIBERS > 1) {
-				console.trace();
+			if (logUseFibersLevel === 1) {
+				console.warn(`[FIBERS_LOG] Using ${fibersMethod}.`);
+				return;
+			}
+
+			const { LOG_USE_FIBERS_INCLUDE_IN_PATH } = process.env;
+			const stackFromError = new Error("[FIBERS_LOG]").stack;
+
+			if (
+				!LOG_USE_FIBERS_INCLUDE_IN_PATH ||
+				stackFromError.includes(LOG_USE_FIBERS_INCLUDE_IN_PATH)
+			) {
+				console.warn(stackFromError);
 			}
 		}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fibers",
-	"version": "5.0.0",
+	"version": "5.0.2",
 	"description": "Cooperative multi-tasking for Javascript",
 	"keywords": [
 		"fiber",


### PR DESCRIPTION
To enable logs using environment variable with params:

`ENABLE_LOG_USE_FIBERS=1` to log calls with fibers.
`ENABLE_LOG_USE_FIBERS=2` to log calls with fibers and print stack trace.

Usages example:
```shell
#!/usr/bin/env bash
echo ">>>>>> NO Log"
node log-fibers-test.js && echo ok
ENABLE_LOG_USE_FIBERS=0 node log-fibers-test.js && echo ok
echo ">>>>>> Log level 1"
ENABLE_LOG_USE_FIBERS=1 node log-fibers-test.js
echo ">>>>>> Log level 2 no filters"
ENABLE_LOG_USE_FIBERS=2 node log-fibers-test.js
echo ">>>>>> Log level 2 with filters matches"
ENABLE_LOG_USE_FIBERS=2 LOG_USE_FIBERS_INCLUDE_IN_PATH=meteor-fibers/node-fibers node log-fibers-test.js
echo ">>>>>> Log level 2 with filters no matches"
ENABLE_LOG_USE_FIBERS=2 LOG_USE_FIBERS_INCLUDE_IN_PATH=meteor-fibers/node2-fibers node log-fibers-test.js
```


To save all output messages in a file using shell redirect
```shell
ENABLE_LOG_USE_FIBERS=2 meteor &> fibers-stack.log
```

